### PR TITLE
Fix URL String for document page.

### DIFF
--- a/docs/product_documents/m5stack-core/m5core_basic.md
+++ b/docs/product_documents/m5stack-core/m5core_basic.md
@@ -43,7 +43,7 @@ and so on.
 
 ## DOCUMENTS
 
--  [Schematic](https://github.com/m5stack/M5-3D_and_PCB/blob/master/M5_Core_SCH(20171206).pdf)
+-  [Schematic](https://github.com/m5stack/M5-3D_and_PCB/blob/master/M5_Core_SCH%2820171206%29.pdf)
 
 -  Example
 

--- a/docs/product_documents/m5stack-core/m5core_gray.md
+++ b/docs/product_documents/m5stack-core/m5core_gray.md
@@ -44,7 +44,7 @@ Motion" via M5Stack GRAY in a day in stead of couple weeks and so on.
 
 ## DOCUMENTS
 
--  [Schematic](https://github.com/m5stack/M5-3D_and_PCB/blob/master/M5_Core_SCH(20171206).pdf)
+-  [Schematic](https://github.com/m5stack/M5-3D_and_PCB/blob/master/M5_Core_SCH%2820171206%29.pdf)
 
 -  Example
 

--- a/docs/product_documents/m5stack-core/minicore_stick.md
+++ b/docs/product_documents/m5stack-core/minicore_stick.md
@@ -1,3 +1,3 @@
 # Stick
 
-## (coming soom...)
+## (coming soon...)


### PR DESCRIPTION
Now, M5Stack document page "https://m5stack.github.io/m5stack-documentation/#/product_documents/m5stack-core/m5core_gray" and m5core_basic have a little mistake.
This pull request fix link URL string.
![screenshot_1](https://user-images.githubusercontent.com/1484182/47427092-42453e80-d7ca-11e8-9daa-05c19a51ad95.png)
